### PR TITLE
Fix unknown props warning on React v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-loader": "^6.2.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-2": "^6.13.0",
     "chai": "^3.4.1",
     "chai-spies": "^0.7.1",
     "karma": "^0.13.19",

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,11 @@ export default class Infinity extends React.Component {
   }
   render() {
     const {disabled, loading} = this.state;
+    const {offsetRatio, onNewData, ...rest} = this.props;
     const enabled = !disabled && !loading; // not listening for onScroll event
                                            // if disabled or loading
     return (
-      <div {...this.props} onScroll={enabled && this.handleScroll.bind(this)}>
+      <div {...rest} onScroll={enabled && this.handleScroll.bind(this)}>
         {this.props.children}
       </div>
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
 				loader: 'babel',
 				exclude: /node_modules/,
 				query: {
-					presets: ['react', 'es2015']
+					presets: ['react', 'es2015', 'stage-2']
 				}
 			}
 		]


### PR DESCRIPTION
I love your simple infinite scrolling component. It's exactly what I need on my projects.

I've just updated React to v15.3.1 on one project and it started returning this warning:

> Warning: Unknown props `onNewData`, `offsetRatio` on div tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop

Provided link explains the issue: https://facebook.github.io/react/warnings/unknown-prop.html

This small PR fixes the warning by omitting `offsetRatio` and `onNewData ` props and passing only the rest of props to `div`.